### PR TITLE
Add Node.js microservices example with gRPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
-# codex
+# Node.js Microservices Example
+
+This repository contains a simple example of two microservices written in TypeScript:
+
+- **auth service** – exposes a gRPC API for registering users, logging in and
+  requesting a password reset.
+- **api gateway** – Express application that exposes HTTP endpoints and
+  communicates with the auth service via gRPC.
+
+## Structure
+
+```
+services/
+  auth/
+    auth.proto        # gRPC definitions
+    src/              # TypeScript source for the gRPC server
+  apigateway/
+    src/              # TypeScript source for the HTTP gateway
+```
+
+Each service has its own `package.json` and `tsconfig.json` for easy independent
+builds.
+
+## Building and running
+
+Install dependencies for each service and build the TypeScript sources:
+
+```bash
+cd services/auth
+npm install
+npm run build
+npm start
+```
+
+In another terminal:
+
+```bash
+cd services/apigateway
+npm install
+npm run build
+npm start
+```
+
+The API gateway listens on port `3000` by default and forwards registration,
+login and forgot password requests to the auth service via gRPC running on
+`localhost:50051`.

--- a/services/apigateway/package.json
+++ b/services/apigateway/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "api-gateway",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "@grpc/grpc-js": "^1.9.9",
+    "@grpc/proto-loader": "^0.7.5"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5",
+    "@types/node": "^20.11.30",
+    "@types/express": "^4.17.21"
+  }
+}

--- a/services/apigateway/src/index.ts
+++ b/services/apigateway/src/index.ts
@@ -1,0 +1,59 @@
+import express from 'express';
+import { credentials, loadPackageDefinition } from '@grpc/grpc-js';
+import { loadSync } from '@grpc/proto-loader';
+
+const PROTO_PATH = __dirname + '/../../auth/auth.proto';
+const packageDefinition = loadSync(PROTO_PATH, {
+  keepCase: true,
+  longs: String,
+  enums: String,
+  defaults: true,
+  oneofs: true,
+});
+const authProto = (loadPackageDefinition(packageDefinition) as any).auth;
+
+const client = new authProto.AuthService(
+  process.env.AUTH_SERVICE_HOST || 'localhost:50051',
+  credentials.createInsecure()
+);
+
+const app = express();
+app.use(express.json());
+
+app.post('/register', (req, res) => {
+  const { email, password } = req.body;
+  client.Register({ email, password }, (err: any, response: any) => {
+    if (err) {
+      console.error(err);
+      return res.status(500).json({ success: false });
+    }
+    res.json(response);
+  });
+});
+
+app.post('/login', (req, res) => {
+  const { email, password } = req.body;
+  client.Login({ email, password }, (err: any, response: any) => {
+    if (err) {
+      console.error(err);
+      return res.status(500).json({ success: false });
+    }
+    res.json(response);
+  });
+});
+
+app.post('/forgot-password', (req, res) => {
+  const { email } = req.body;
+  client.ForgotPassword({ email }, (err: any, response: any) => {
+    if (err) {
+      console.error(err);
+      return res.status(500).json({ success: false });
+    }
+    res.json(response);
+  });
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`API Gateway listening on port ${PORT}`);
+});

--- a/services/apigateway/tsconfig.json
+++ b/services/apigateway/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"]
+}

--- a/services/auth/auth.proto
+++ b/services/auth/auth.proto
@@ -1,0 +1,36 @@
+syntax = "proto3";
+
+package auth;
+
+service AuthService {
+  rpc Register (RegisterRequest) returns (RegisterResponse);
+  rpc Login (LoginRequest) returns (LoginResponse);
+  rpc ForgotPassword (ForgotPasswordRequest) returns (ForgotPasswordResponse);
+}
+
+message RegisterRequest {
+  string email = 1;
+  string password = 2;
+}
+
+message RegisterResponse {
+  bool success = 1;
+}
+
+message LoginRequest {
+  string email = 1;
+  string password = 2;
+}
+
+message LoginResponse {
+  bool success = 1;
+  string token = 2;
+}
+
+message ForgotPasswordRequest {
+  string email = 1;
+}
+
+message ForgotPasswordResponse {
+  bool success = 1;
+}

--- a/services/auth/package.json
+++ b/services/auth/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "auth-service",
+  "version": "1.0.0",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@grpc/grpc-js": "^1.9.9",
+    "@grpc/proto-loader": "^0.7.5"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5",
+    "@types/node": "^20.11.30"
+  }
+}

--- a/services/auth/src/index.ts
+++ b/services/auth/src/index.ts
@@ -1,0 +1,74 @@
+import { loadPackageDefinition, Server, ServerCredentials } from '@grpc/grpc-js';
+import { loadSync } from '@grpc/proto-loader';
+import { randomBytes, pbkdf2Sync } from 'crypto';
+
+const PROTO_PATH = __dirname + '/../auth.proto';
+
+const packageDefinition = loadSync(PROTO_PATH, {
+  keepCase: true,
+  longs: String,
+  enums: String,
+  defaults: true,
+  oneofs: true,
+});
+
+const authProto = (loadPackageDefinition(packageDefinition) as any).auth;
+
+interface User {
+  email: string;
+  passwordHash: string;
+  salt: string;
+}
+
+const users = new Map<string, User>();
+
+function hashPassword(password: string, salt: string) {
+  return pbkdf2Sync(password, salt, 1000, 64, 'sha512').toString('hex');
+}
+
+const server = new Server();
+
+server.addService(authProto.AuthService.service, {
+  Register: (call: any, callback: any) => {
+    const { email, password } = call.request;
+    if (users.has(email)) {
+      return callback(null, { success: false });
+    }
+    const salt = randomBytes(16).toString('hex');
+    const passwordHash = hashPassword(password, salt);
+    users.set(email, { email, passwordHash, salt });
+    return callback(null, { success: true });
+  },
+  Login: (call: any, callback: any) => {
+    const { email, password } = call.request;
+    const user = users.get(email);
+    if (!user) {
+      return callback(null, { success: false });
+    }
+    const hashed = hashPassword(password, user.salt);
+    if (hashed !== user.passwordHash) {
+      return callback(null, { success: false });
+    }
+    const token = randomBytes(16).toString('hex');
+    return callback(null, { success: true, token });
+  },
+  ForgotPassword: (call: any, callback: any) => {
+    const { email } = call.request;
+    if (!users.has(email)) {
+      return callback(null, { success: false });
+    }
+    // In a real app we'd send an email here
+    return callback(null, { success: true });
+  },
+});
+
+const PORT = process.env.PORT || '50051';
+
+server.bindAsync(`0.0.0.0:${PORT}`, ServerCredentials.createInsecure(), (err, port) => {
+  if (err) {
+    console.error('Failed to start gRPC server', err);
+    return;
+  }
+  server.start();
+  console.log(`Auth service gRPC server running on port ${port}`);
+});

--- a/services/auth/tsconfig.json
+++ b/services/auth/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- create AuthService gRPC definition
- implement a gRPC auth service with TypeScript
- implement an Express API gateway that talks to the auth service via gRPC
- document project layout and build instructions

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_68449298b3a08323a8081ba45bc5022e